### PR TITLE
feat: point data order in xdmf

### DIFF
--- a/graphphysics/dataset/xdmf_dataset.py
+++ b/graphphysics/dataset/xdmf_dataset.py
@@ -127,9 +127,9 @@ class XDMFDataset(BaseDataset):
 
         if self.use_previous_data:
             previous = {
-                k: np.array(v).astype(self.meta["features"][k]["dtype"])
-                for k, v in previous_data.items()
-                if k in self.meta["features"]
+                k: np.array(previous_data[k]).astype(self.meta["features"][k]["dtype"])
+                for k in self.meta["features"]
+                if k in previous_data.keys()
                 and self.meta["features"][k]["type"] == "dynamic"
             }
             _reshape_array(previous)


### PR DESCRIPTION
Currently, when creating point_data dictionnary in xdmf_dataset.py (line 95-99), the order of the keys is the one of mesh.point_data(). But this order is quite random, so knowing after that which column corresponds to which physical field is impossible. However, we need to know this order to retrieve properly the features in build_features.

It would make more sense to create this point_data dictionnary following the order defined in the field_names list of the dataset_config .json file.

The code is currently:
`point_data = { k: np.array(v).astype(self.meta["features"][k]["dtype"]) for k, v in point_data.items() if k in self.meta["features"] }`

And could be turned into:
`point_data = { k: np.array(mesh.point_data[k]).astype(self.meta["features"][k]["dtype"]) for k in self.meta["features"] if k in mesh.point_data.keys() }`