### PR TITLE
Add random edges

### DIFF
--- a/graphphysics/dataset/h5_dataset.py
+++ b/graphphysics/dataset/h5_dataset.py
@@ -19,6 +19,7 @@ class H5Dataset(BaseDataset):
         preprocessing: Optional[Callable[[Data], Data]] = None,
         masking_ratio: Optional[float] = None,
         khop: int = 1,
+        new_edges_ratio: float = 0,
         add_edge_features: bool = True,
         use_previous_data: bool = False,
         switch_to_val: bool = False,
@@ -28,6 +29,7 @@ class H5Dataset(BaseDataset):
             preprocessing=preprocessing,
             masking_ratio=masking_ratio,
             khop=khop,
+            new_edges_ratio=new_edges_ratio,
             add_edge_features=add_edge_features,
             use_previous_data=use_previous_data,
         )
@@ -90,6 +92,7 @@ class H5Dataset(BaseDataset):
         graph = self._apply_preprocessing(graph)
         graph = self._apply_k_hop(graph, traj_index)
         graph = self._may_remove_edges_attr(graph)
+        graph = self._add_random_edges(graph)
         selected_indices = self._get_masked_indexes(graph)
 
         del graph.previous_data

--- a/graphphysics/dataset/xdmf_dataset.py
+++ b/graphphysics/dataset/xdmf_dataset.py
@@ -18,6 +18,7 @@ class XDMFDataset(BaseDataset):
         preprocessing: Optional[Callable[[Data], Data]] = None,
         masking_ratio: Optional[float] = None,
         khop: int = 1,
+        new_edges_ratio: float = 0,
         add_edge_features: bool = True,
         use_previous_data: bool = False,
         switch_to_val: bool = False,
@@ -27,6 +28,7 @@ class XDMFDataset(BaseDataset):
             preprocessing=preprocessing,
             masking_ratio=masking_ratio,
             khop=khop,
+            new_edges_ratio=new_edges_ratio,
             add_edge_features=add_edge_features,
             use_previous_data=use_previous_data,
         )
@@ -140,6 +142,7 @@ class XDMFDataset(BaseDataset):
         graph = self._apply_preprocessing(graph)
         graph = self._apply_k_hop(graph, traj_index)
         graph = self._may_remove_edges_attr(graph)
+        graph = self._add_random_edges(graph)
         selected_indices = self._get_masked_indexes(graph)
 
         del graph.previous_data

--- a/graphphysics/training/parse_parameters.py
+++ b/graphphysics/training/parse_parameters.py
@@ -166,6 +166,7 @@ def get_dataset(
     """
     dataset_params = param.get("dataset", {})
     khop = dataset_params.get("khop", 1)
+    new_edges_ratio = dataset_params.get("new_edges_ratio", 0)
     extension = dataset_params.get("extension", "")
 
     if extension == "h5":
@@ -175,6 +176,7 @@ def get_dataset(
             preprocessing=preprocessing,
             masking_ratio=masking_ratio,
             khop=khop,
+            new_edges_ratio=new_edges_ratio,
             add_edge_features=use_edge_feature,
             use_previous_data=use_previous_data,
             switch_to_val=switch_to_val,
@@ -186,6 +188,7 @@ def get_dataset(
             preprocessing=preprocessing,
             masking_ratio=masking_ratio,
             khop=khop,
+            new_edges_ratio=new_edges_ratio,
             add_edge_features=use_edge_feature,
             use_previous_data=use_previous_data,
             switch_to_val=switch_to_val,

--- a/graphphysics/utils/torch_graph.py
+++ b/graphphysics/utils/torch_graph.py
@@ -84,10 +84,7 @@ def compute_k_hop_graph(
 
     # Build k-hop graph
     khop_mesh_graph = Data(
-        x=graph.x,
-        edge_index=khop_edge_index,
-        pos=graph.pos,
-        y=graph.y,
+        x=graph.x, edge_index=khop_edge_index, pos=graph.pos, y=graph.y, face=graph.face
     )
 
     # Optionally compute edge features

--- a/tests/graphphysics/dataset/test_h5dataset.py
+++ b/tests/graphphysics/dataset/test_h5dataset.py
@@ -81,6 +81,25 @@ class TestH5DatasetPreprocessingNoEdgeFeatures(unittest.TestCase):
         assert graph.edge_attr is None
 
 
+class TestH5DatasetPreprocessingRE(unittest.TestCase):
+    def setUp(self):
+        transform = build_preprocessing(add_edges_features=True)
+        self.dataset = H5Dataset(
+            h5_path=MOCK_H5_SAVE_PATH,
+            meta_path=MOCK_H5_META_SAVE_PATH,
+            preprocessing=transform,
+            new_edges_ratio=0.5,
+        )
+        self.dataset.trajectory_length += 1
+
+    def test_get(self):
+        graph = self.dataset[0]
+        assert graph.num_nodes == 1876
+        assert graph.edge_index.shape == (2, 16182)
+        assert graph.edge_attr.shape == (16182, 3)
+        assert graph.face is not None
+
+
 class TestH5DatasetPreprocessingKHOP(unittest.TestCase):
     def setUp(self):
         transform = build_preprocessing(add_edges_features=True)
@@ -97,7 +116,26 @@ class TestH5DatasetPreprocessingKHOP(unittest.TestCase):
         assert graph.num_nodes == 1876
         assert graph.edge_index.shape == (2, 31746)
         assert graph.edge_attr.shape == (31746, 3)
-        assert graph.face is None
+        assert graph.face is not None
+
+
+class TestH5DatasetPreprocessingNoEdgeFeaturesRE(unittest.TestCase):
+    def setUp(self):
+        transform = build_preprocessing(add_edges_features=True)
+        self.dataset = H5Dataset(
+            h5_path=MOCK_H5_SAVE_PATH,
+            meta_path=MOCK_H5_META_SAVE_PATH,
+            preprocessing=transform,
+            new_edges_ratio=0.5,
+            add_edge_features=False,
+        )
+        self.dataset.trajectory_length += 1
+
+    def test_get(self):
+        graph = self.dataset[0]
+        assert graph.num_nodes == 1876
+        assert graph.edge_index.shape == (2, 16182)
+        assert graph.edge_attr is None
 
 
 class TestH5DatasetPreprocessingNoEdgeFeaturesKHOP(unittest.TestCase):

--- a/tests/graphphysics/dataset/test_xdmfdataset.py
+++ b/tests/graphphysics/dataset/test_xdmfdataset.py
@@ -17,7 +17,7 @@ from graphphysics.utils.nodetype import NodeType
 from graphphysics.external.aneurysm import aneurysm_node_type
 
 
-class TestH5Dataset(unittest.TestCase):
+class TestXDMFDataset(unittest.TestCase):
     def setUp(self):
         self.dataset = XDMFDataset(
             xdmf_folder=MOCK_XDMF_FOLDER,
@@ -34,7 +34,7 @@ class TestH5Dataset(unittest.TestCase):
         assert graph.edge_index is None
 
 
-class TestH5DatasetDistance(unittest.TestCase):
+class TestXDMFDatasetDistance(unittest.TestCase):
     def setUp(self):
         self.dataset = XDMFDataset(
             xdmf_folder="tests/mock_xdmf_aneurysm",
@@ -96,7 +96,7 @@ class TestH5DatasetDistance(unittest.TestCase):
         mesh.write("test_distance.vtu")
 
 
-class TestH5DatasetRotating(unittest.TestCase):
+class TestXDMFDatasetRotating(unittest.TestCase):
     def setUp(self):
         self.dataset = XDMFDataset(
             xdmf_folder="tests/mock_xdmf_aneurysm",
@@ -141,7 +141,7 @@ class TestH5DatasetRotating(unittest.TestCase):
         mesh.write("test_rotate.vtu")
 
 
-class TestH5DatasetMasking(unittest.TestCase):
+class TestXDMFDatasetMasking(unittest.TestCase):
     def setUp(self):
         self.dataset = XDMFDataset(
             xdmf_folder=MOCK_XDMF_FOLDER,
@@ -175,7 +175,7 @@ class TestH5DatasetPreprocessing(unittest.TestCase):
         assert graph.edge_attr.shape == (11070, 4)
 
 
-class TestH5DatasetPreprocessingNoEdgeFeatures(unittest.TestCase):
+class TestXDMFDatasetPreprocessingNoEdgeFeatures(unittest.TestCase):
     def setUp(self):
         transform = build_preprocessing(add_edges_features=False)
         self.dataset = XDMFDataset(
@@ -193,7 +193,26 @@ class TestH5DatasetPreprocessingNoEdgeFeatures(unittest.TestCase):
         assert graph.edge_attr is None
 
 
-class TestH5DatasetPreprocessingKHOP(unittest.TestCase):
+class TestXDMFDatasetPreprocessingRE(unittest.TestCase):
+    def setUp(self):
+        transform = build_preprocessing(add_edges_features=True)
+        self.dataset = XDMFDataset(
+            xdmf_folder=MOCK_XDMF_FOLDER,
+            meta_path=MOCK_H5_META10_SAVE_PATH,
+            preprocessing=transform,
+            new_edges_ratio=0.5,
+        )
+        self.dataset.trajectory_length += 1
+
+    def test_get(self):
+        graph = self.dataset[0]
+        assert graph.num_nodes == 1923
+        assert graph.edge_index.shape == (2, 16604)
+        assert graph.edge_attr.shape == (16604, 4)
+        assert graph.face is not None
+
+
+class TestXDMFDatasetPreprocessingKHOP(unittest.TestCase):
     def setUp(self):
         transform = build_preprocessing(add_edges_features=True)
         self.dataset = XDMFDataset(
@@ -209,10 +228,29 @@ class TestH5DatasetPreprocessingKHOP(unittest.TestCase):
         assert graph.num_nodes == 1923
         assert graph.edge_index.shape == (2, 32638)
         assert graph.edge_attr.shape == (32638, 4)
-        assert graph.face is None
+        assert graph.face is not None
 
 
-class TestH5DatasetPreprocessingNoEdgeFeaturesKHOP(unittest.TestCase):
+class TestXDMFDatasetPreprocessingNoEdgeFeaturesRE(unittest.TestCase):
+    def setUp(self):
+        transform = build_preprocessing(add_edges_features=True)
+        self.dataset = XDMFDataset(
+            xdmf_folder=MOCK_XDMF_FOLDER,
+            meta_path=MOCK_H5_META10_SAVE_PATH,
+            preprocessing=transform,
+            new_edges_ratio=0.5,
+            add_edge_features=False,
+        )
+        self.dataset.trajectory_length += 1
+
+    def test_get(self):
+        graph = self.dataset[0]
+        assert graph.num_nodes == 1923
+        assert graph.edge_index.shape == (2, 16604)
+        assert graph.edge_attr is None
+
+
+class TestXDMFDatasetPreprocessingNoEdgeFeaturesKHOP(unittest.TestCase):
     def setUp(self):
         transform = build_preprocessing(add_edges_features=False)
         self.dataset = XDMFDataset(

--- a/training_config/c-a-gmm.json
+++ b/training_config/c-a-gmm.json
@@ -3,7 +3,8 @@
         "extension": "xdmf",
         "xdmf_folder": "dataset/train",
         "meta_path": "dataset/meta.json",
-        "khop": 1
+        "khop": 1,
+        "new_edges_ratio": 0
     },
     "model": {
         "type": "transformer",

--- a/training_config/coarse-aneurysm.json
+++ b/training_config/coarse-aneurysm.json
@@ -3,7 +3,8 @@
         "extension": "xdmf",
         "xdmf_folder": "dataset/train",
         "meta_path": "dataset/meta.json",
-        "khop": 1
+        "khop": 1,
+        "new_edges_ratio": 0
     },
     "model": {
         "type": "transformer",

--- a/training_config/panels.json
+++ b/training_config/panels.json
@@ -3,7 +3,8 @@
         "extension": "xdmf",
         "xdmf_folder": "dataset/train",
         "meta_path": "dataset/meta.json",
-        "khop": 1
+        "khop": 1,
+        "new_edges_ratio": 0
     },
     "model": {
         "type": "transformer",

--- a/training_config/plate.json
+++ b/training_config/plate.json
@@ -3,7 +3,8 @@
         "extension": "h5",
         "h5_path": "dataset/h5_dataset/deforming_plate/train.h5",
         "meta_path": "dataset/h5_dataset/deforming_plate/meta.json",
-        "khop": 2
+        "khop": 2,
+        "new_edges_ratio": 0
     },
     "model": {
         "type": "mps",


### PR DESCRIPTION
Adds random connection in a graph. We used to do it directly on the adjacency matrix, but since this method can also help regular message passing, we implement it directly on graph in the Dataset class. 

Since we are adding edges after they have been created (and thus after we've already created their features), we also need to recompute them if we specify their usage. 

The key function is: 

```
new_edge_index, _ = add_random_edge(
            edge_index, p=new_edges_ratio, force_undirected=True
        )
```

> Note: we do not switch training to `False` during validation, because we want to keep adding edges even during validation. 

- small bug fix: when using khop > 1, we where creating a new graph without their faces, which would have failed during .xdmf saving time in `on_validation_epoch_end`
- small typo in the test names in the xdmf dataset