### PR TITLE
feat: add graph masking and reconstruction

### DIFF
--- a/graphphysics/utils/meshmask.py
+++ b/graphphysics/utils/meshmask.py
@@ -1,0 +1,91 @@
+import torch
+from torch_geometric.data import Data
+from torch_geometric.utils.num_nodes import maybe_num_nodes
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def filter_edges(edge_index: torch.Tensor, node_index: torch.Tensor):
+    """Filters edges based on the given node indices.
+
+    Args:
+        edge_index (Tensor): The edge indices.
+        node_index (Tensor): The node indices to filter.
+
+    Returns:
+        Tuple[Tensor, Tensor]: Filtered edge indices and attributes.
+    """
+    num_nodes = maybe_num_nodes(edge_index, None)
+    node_index = node_index.to(device)
+    cluster_index = torch.arange(node_index.size(0), device=node_index.device)
+
+    mask = node_index.new_full((num_nodes,), -1).to(device)
+    mask[node_index] = cluster_index
+
+    row, col = edge_index[0], edge_index[1]
+    row, col = mask[row], mask[col]
+    mask = (row >= 0) & (col >= 0)
+    row, col = row[mask], col[mask]
+
+    return torch.stack([row, col], dim=0), mask
+
+
+def build_masked_graph(
+    masked_graph: Data,
+    selected_indexes: torch.Tensor,
+):
+    """
+    Masks a PyTorch Geometric Data object based on selected indices.
+
+    This function creates a masked version of the input graph by selecting only the nodes and edges
+    specified by the provided indices. It updates the node features, positions, edge attributes, and
+    edge indices accordingly.
+
+    Parameters:
+        - masked_graph: A PyTorch Geometric Data object to be masked.
+        - selected_indexes: A tensor containing the indices of the nodes to be selected.
+
+    Returns:
+        A masked PyTorch Geometric Data object based on the selected indices.
+    """
+    masked_e_index, _ = filter_edges(masked_graph.edge_index, selected_indexes)
+
+    masked_graph.edge_index = masked_e_index
+    masked_graph.x = masked_graph.x[selected_indexes]
+    masked_graph.pos = masked_graph.pos[selected_indexes]
+
+    return masked_graph
+
+
+def reconstruct_graph(
+    graph: Data,
+    latent_masked_graph: Data,
+    selected_indexes: torch.Tensor,
+    node_mask_token: torch.nn.Parameter,
+) -> Data:
+    """
+    Given a graph and it's masked version, we assign a feature vector for each node based on:
+      - it's computed value inside of the `latent_masked_graph` if this node was not masked
+      - a [MASK] token otherwise
+
+    The [MASK] token should be initialized and trained inside of the Masked Decoder as the
+    following attribute: `self.node_mask_token = torch.nn.Parameter(torch.zeros(embedding_dim))`
+
+    Parameters:
+        - graph: A PyTorch Geometric Data object to be reconstructed.
+        - latent_masked_graph: A Masked PyTorch Geometric Data object to be fetch features from.
+        - selected_indexes: A tensor containing the indices of the nodes to be selected.
+        - node_mask_token: torch.nn.Parameter to be used as a [MASK] token
+
+    Returns:
+        A PyTorch Geometric Data object.
+    """
+    n, f = graph.x.shape
+    features = torch.zeros(n, f).to(device)
+    features += node_mask_token.expand(n, -1)
+    features[selected_indexes] = latent_masked_graph.x
+
+    latent_graph = graph.clone()
+    latent_graph.x = features
+
+    return latent_graph

--- a/graphphysics/utils/meshmask.py
+++ b/graphphysics/utils/meshmask.py
@@ -17,7 +17,7 @@ def filter_edges(
         node_index (Tensor): The node indices to filter.
 
     Returns:
-        Tuple[Tensor, Tensor]: Filtered edge indices and attributes.
+        Tuple[Tensor, Tensor, Tensor]: Filtered edge indices and attributes, and the node masked index.
     """
     num_nodes = maybe_num_nodes(edge_index, None)
     node_index = node_index.to(device)
@@ -53,7 +53,7 @@ def build_masked_graph(
         - selected_indexes: A tensor containing the indices of the nodes to be selected.
 
     Returns:
-        A masked PyTorch Geometric Data object based on the selected indices.
+        A masked PyTorch Geometric Data object based on the selected indices, and the edge masked index.
     """
     masked_e_index, masked_e_attr, edges_mask = filter_edges(
         masked_graph.edge_index, selected_indexes, masked_graph.edge_attr

--- a/tests/graphphysics/utils/test_meshmask.py
+++ b/tests/graphphysics/utils/test_meshmask.py
@@ -1,0 +1,220 @@
+import unittest
+import torch
+from torch import nn
+from torch_geometric.data import Data
+from graphphysics.utils.meshmask import (
+    filter_edges,
+    build_masked_graph,
+    reconstruct_graph,
+)
+
+
+class TestGraphFunctions(unittest.TestCase):
+
+    def setUp(self):
+        """Set up common test data."""
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+        self.edge_index1 = torch.tensor(
+            [[0, 1, 1, 2, 3, 4], [1, 0, 2, 1, 4, 3]], dtype=torch.long
+        )
+        self.x1 = torch.randn(5, 16)
+        self.pos1 = torch.randn(5, 3)
+        self.graph1 = Data(x=self.x1, edge_index=self.edge_index1, pos=self.pos1).to(
+            self.device
+        )
+
+    def test_filter_edges_basic(self):
+        """Test filtering edges with a subset of nodes."""
+        node_index = torch.tensor([0, 1, 2], dtype=torch.long).to(
+            self.device
+        )  # Keep nodes 0, 1, 2
+        expected_edge_index = torch.tensor(
+            [[0, 1, 1, 2], [1, 0, 2, 1]], dtype=torch.long
+        ).to(self.device)
+        # Edges expected: 0-1, 1-0, 1-2, 2-1 (remapped)
+
+        filtered_ei, mask = filter_edges(self.graph1.edge_index, node_index)
+
+        self.assertTrue(torch.equal(filtered_ei, expected_edge_index))
+        self.assertEqual(filtered_ei.device.type, self.device.type)
+        self.assertEqual(mask.sum(), 4)  # 4 edges should be kept
+        self.assertEqual(
+            mask.shape[0], self.graph1.edge_index.shape[1]
+        )  # Mask size = num original edges
+        original_edges_kept = self.graph1.edge_index[:, mask]
+        self.assertTrue(
+            (original_edges_kept < 3).all()
+        )  # All nodes in kept edges should be < 3
+
+    def test_filter_edges_no_common_edges(self):
+        """Test filtering when selected nodes have no edges between them."""
+        node_index = torch.tensor([0, 3], dtype=torch.long).to(
+            self.device
+        )  # Keep nodes 0, 3
+        expected_edge_index = torch.empty((2, 0), dtype=torch.long).to(self.device)
+
+        filtered_ei, mask = filter_edges(self.graph1.edge_index, node_index)
+
+        self.assertTrue(torch.equal(filtered_ei, expected_edge_index))
+        self.assertEqual(filtered_ei.device.type, self.device.type)
+        self.assertEqual(mask.sum(), 0)
+
+    def test_filter_edges_empty_selection(self):
+        """Test filtering with empty node_index."""
+        node_index = torch.tensor([], dtype=torch.long).to(self.device)
+        expected_edge_index = torch.empty((2, 0), dtype=torch.long).to(self.device)
+
+        filtered_ei, mask = filter_edges(self.graph1.edge_index, node_index)
+
+        self.assertTrue(torch.equal(filtered_ei, expected_edge_index))
+        self.assertEqual(filtered_ei.device.type, self.device.type)
+        self.assertEqual(mask.sum(), 0)
+
+    def test_build_masked_graph_basic(self):
+        """Test building a masked graph with features and positions."""
+        selected_indexes = torch.tensor([0, 1, 2], dtype=torch.long).to(self.device)
+        graph_to_mask = self.graph1.clone()
+
+        masked_graph = build_masked_graph(graph_to_mask, selected_indexes)
+
+        expected_edge_index = torch.tensor(
+            [[0, 1, 1, 2], [1, 0, 2, 1]], dtype=torch.long
+        ).to(self.device)
+        expected_x = self.graph1.x[selected_indexes]
+        expected_pos = self.graph1.pos[selected_indexes]
+
+        self.assertEqual(masked_graph.num_nodes, 3)
+        torch.testing.assert_close(masked_graph.x, expected_x)
+        torch.testing.assert_close(masked_graph.pos, expected_pos)
+        self.assertTrue(torch.equal(masked_graph.edge_index, expected_edge_index))
+        self.assertEqual(masked_graph.x.device.type, self.device.type)
+        self.assertEqual(masked_graph.pos.device.type, self.device.type)
+        self.assertEqual(masked_graph.edge_index.device.type, self.device.type)
+
+    def test_build_masked_graph_select_all(self):
+        """Test building a masked graph selecting all nodes (should be identity)."""
+        selected_indexes = torch.arange(self.graph1.num_nodes, dtype=torch.long).to(
+            self.device
+        )
+        graph_to_mask = self.graph1.clone()
+
+        masked_graph = build_masked_graph(graph_to_mask, selected_indexes)
+
+        expected_edge_index = torch.tensor(
+            [[0, 1, 1, 2, 3, 4], [1, 0, 2, 1, 4, 3]], dtype=torch.long
+        ).to(self.device)
+
+        self.assertEqual(masked_graph.num_nodes, self.graph1.num_nodes)
+        torch.testing.assert_close(masked_graph.x, self.graph1.x)
+        torch.testing.assert_close(masked_graph.pos, self.graph1.pos)
+        self.assertTrue(torch.equal(masked_graph.edge_index, expected_edge_index))
+
+    def test_reconstruct_graph_basic(self):
+        """Test reconstructing a graph from its masked latent version."""
+        original_graph = self.graph1.clone()
+        selected_indexes = torch.tensor([0, 2, 4], dtype=torch.long).to(self.device)
+        embedding_dim = original_graph.x.shape[1]
+
+        # Simulate a latent masked graph (e.g., output of an encoder)
+        # Has features only for selected nodes (3 nodes), potentially modified
+        latent_x = torch.randn(3, embedding_dim).to(self.device)
+        latent_masked_graph = Data(x=latent_x).to(
+            self.device
+        )  # Only need x for this function's perspective
+
+        # Mask token
+        mask_token = nn.Parameter(torch.zeros(embedding_dim, device=self.device))
+        mask_token.data += 0.5  # Give it a non-zero value for easier testing
+
+        reconstructed_graph = reconstruct_graph(
+            original_graph, latent_masked_graph, selected_indexes, mask_token
+        )
+
+        self.assertEqual(reconstructed_graph.num_nodes, original_graph.num_nodes)
+        self.assertEqual(reconstructed_graph.x.shape, original_graph.x.shape)
+        self.assertEqual(reconstructed_graph.x.device.type, self.device.type)
+
+        # Check selected nodes have features from latent graph
+        torch.testing.assert_close(reconstructed_graph.x[selected_indexes], latent_x)
+
+        # Check unselected nodes have the mask token
+        unselected_mask = torch.ones(
+            original_graph.num_nodes, dtype=torch.bool, device=self.device
+        )
+        unselected_mask[selected_indexes] = False
+        expected_mask_features = mask_token.data.unsqueeze(0).expand(
+            unselected_mask.sum(), -1
+        )
+        torch.testing.assert_close(
+            reconstructed_graph.x[unselected_mask], expected_mask_features
+        )
+
+        # Check other attributes are preserved
+        self.assertTrue(
+            torch.equal(reconstructed_graph.edge_index, original_graph.edge_index)
+        )
+        torch.testing.assert_close(reconstructed_graph.pos, original_graph.pos)
+        self.assertEqual(reconstructed_graph.edge_index.device.type, self.device.type)
+        self.assertEqual(reconstructed_graph.pos.device.type, self.device.type)
+
+    def test_reconstruct_graph_select_all(self):
+        """Test reconstructing when all nodes were selected."""
+        original_graph = self.graph1.clone()
+        selected_indexes = torch.arange(original_graph.num_nodes, dtype=torch.long).to(
+            self.device
+        )
+        embedding_dim = original_graph.x.shape[1]
+
+        # Latent graph has features for all nodes
+        latent_x = torch.randn(original_graph.num_nodes, embedding_dim).to(self.device)
+        latent_masked_graph = Data(x=latent_x).to(self.device)
+
+        mask_token = nn.Parameter(torch.zeros(embedding_dim, device=self.device))
+
+        reconstructed_graph = reconstruct_graph(
+            original_graph, latent_masked_graph, selected_indexes, mask_token
+        )
+
+        self.assertEqual(reconstructed_graph.num_nodes, original_graph.num_nodes)
+        # All features should come from the latent graph
+        torch.testing.assert_close(reconstructed_graph.x, latent_x)
+        # Check other attributes
+        self.assertTrue(
+            torch.equal(reconstructed_graph.edge_index, original_graph.edge_index)
+        )
+        torch.testing.assert_close(reconstructed_graph.pos, original_graph.pos)
+
+    def test_reconstruct_graph_select_none(self):
+        """Test reconstructing when no nodes were selected."""
+        original_graph = self.graph1.clone()
+        selected_indexes = torch.tensor([], dtype=torch.long).to(self.device)
+        embedding_dim = original_graph.x.shape[1]
+
+        # Latent graph has features for 0 nodes
+        latent_x = torch.empty((0, embedding_dim), device=self.device)
+        latent_masked_graph = Data(x=latent_x).to(self.device)
+
+        mask_token = nn.Parameter(
+            torch.ones(embedding_dim, device=self.device) * -1.0
+        )  # Use a specific value
+
+        reconstructed_graph = reconstruct_graph(
+            original_graph, latent_masked_graph, selected_indexes, mask_token
+        )
+
+        self.assertEqual(reconstructed_graph.num_nodes, original_graph.num_nodes)
+        # All features should be the mask token
+        expected_mask_features = mask_token.data.unsqueeze(0).expand(
+            original_graph.num_nodes, -1
+        )
+        torch.testing.assert_close(reconstructed_graph.x, expected_mask_features)
+        # Check other attributes
+        self.assertTrue(
+            torch.equal(reconstructed_graph.edge_index, original_graph.edge_index)
+        )
+        torch.testing.assert_close(reconstructed_graph.pos, original_graph.pos)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/graphphysics/utils/test_meshmask.py
+++ b/tests/graphphysics/utils/test_meshmask.py
@@ -9,211 +9,309 @@ from graphphysics.utils.meshmask import (
 )
 
 
-class TestGraphFunctions(unittest.TestCase):
+class TestGraphFunctionsUpdated(unittest.TestCase):
 
     def setUp(self):
         """Set up common test data."""
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.node_feature_dim = 16
+        self.edge_feature_dim = 8
 
+        # Sample Graph 1 (5 nodes, 6 edges with attributes)
         self.edge_index1 = torch.tensor(
             [[0, 1, 1, 2, 3, 4], [1, 0, 2, 1, 4, 3]], dtype=torch.long
         )
-        self.x1 = torch.randn(5, 16)
+        self.x1 = torch.randn(5, self.node_feature_dim)
         self.pos1 = torch.randn(5, 3)
-        self.graph1 = Data(x=self.x1, edge_index=self.edge_index1, pos=self.pos1).to(
+        self.edge_attr1 = torch.randn(6, self.edge_feature_dim)  # One attr per edge
+        self.graph1 = Data(
+            x=self.x1,
+            edge_index=self.edge_index1,
+            pos=self.pos1,
+            edge_attr=self.edge_attr1,
+        ).to(self.device)
+
+        # Sample Graph 2 (4 nodes, 2 edges, no edge_attr, no pos)
+        self.edge_index2 = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+        self.x2 = torch.randn(4, self.node_feature_dim)
+        self.graph2 = Data(x=self.x2, edge_index=self.edge_index2).to(self.device)
+
+        # Reconstruct components
+        self.node_mask_token = nn.Parameter(
+            torch.randn(1, self.node_feature_dim) * 0.1
+        ).to(
+            self.device
+        )  # Single row, expand later
+        self.edge_mask_token = nn.Parameter(
+            torch.randn(1, self.edge_feature_dim) * 0.2
+        ).to(
+            self.device
+        )  # Single row, expand later
+        # Simple linear encoder for testing edge reconstruction
+        self.edge_encoder = nn.Linear(self.edge_feature_dim, self.edge_feature_dim).to(
             self.device
         )
+        # Identity encoder for simpler testing
+        self.identity_encoder = nn.Identity().to(self.device)
 
-    def test_filter_edges_basic(self):
-        """Test filtering edges with a subset of nodes."""
+    # --- Tests for filter_edges ---
+
+    def test_filter_edges_with_attr(self):
+        """Test filtering edges with attributes."""
         node_index = torch.tensor([0, 1, 2], dtype=torch.long).to(
             self.device
         )  # Keep nodes 0, 1, 2
-        expected_edge_index = torch.tensor(
-            [[0, 1, 1, 2], [1, 0, 2, 1]], dtype=torch.long
+        expected_ei = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]], dtype=torch.long).to(
+            self.device
+        )
+        expected_mask = torch.tensor(
+            [True, True, True, True, False, False], dtype=torch.bool
         ).to(self.device)
-        # Edges expected: 0-1, 1-0, 1-2, 2-1 (remapped)
+        expected_ea = self.graph1.edge_attr[expected_mask]
 
-        filtered_ei, mask = filter_edges(self.graph1.edge_index, node_index)
+        filtered_ei, filtered_ea, mask = filter_edges(
+            self.graph1.edge_index, node_index, self.graph1.edge_attr
+        )
 
-        self.assertTrue(torch.equal(filtered_ei, expected_edge_index))
+        self.assertTrue(torch.equal(filtered_ei, expected_ei))
         self.assertEqual(filtered_ei.device.type, self.device.type)
-        self.assertEqual(mask.sum(), 4)  # 4 edges should be kept
-        self.assertEqual(
-            mask.shape[0], self.graph1.edge_index.shape[1]
-        )  # Mask size = num original edges
-        original_edges_kept = self.graph1.edge_index[:, mask]
-        self.assertTrue(
-            (original_edges_kept < 3).all()
-        )  # All nodes in kept edges should be < 3
+        torch.testing.assert_close(filtered_ea, expected_ea)
+        self.assertEqual(filtered_ea.device.type, self.device.type)
+        self.assertTrue(torch.equal(mask, expected_mask))
+        self.assertEqual(mask.device.type, self.device.type)
 
-    def test_filter_edges_no_common_edges(self):
-        """Test filtering when selected nodes have no edges between them."""
+    def test_filter_edges_without_attr(self):
+        """Test filtering edges when edge_attr is None."""
+        node_index = torch.tensor([0, 1], dtype=torch.long).to(
+            self.device
+        )  # Keep nodes 0, 1
+        expected_ei = torch.tensor([[0, 1], [1, 0]], dtype=torch.long).to(self.device)
+        expected_mask = torch.tensor([True, True], dtype=torch.bool).to(self.device)
+
+        # Use graph2 which has no edge_attr
+        filtered_ei, filtered_ea, mask = filter_edges(
+            self.graph2.edge_index, node_index, None
+        )  # Explicitly pass None
+
+        self.assertTrue(torch.equal(filtered_ei, expected_ei))
+        self.assertIsNone(filtered_ea)  # Expect None for attributes
+        self.assertTrue(torch.equal(mask, expected_mask))
+
+    def test_filter_edges_no_common_edges_with_attr(self):
+        """Test filtering with attributes when selected nodes have no common edges."""
         node_index = torch.tensor([0, 3], dtype=torch.long).to(
             self.device
         )  # Keep nodes 0, 3
-        expected_edge_index = torch.empty((2, 0), dtype=torch.long).to(self.device)
+        expected_ei = torch.empty((2, 0), dtype=torch.long).to(self.device)
+        expected_mask = torch.tensor(
+            [False, False, False, False, False, False], dtype=torch.bool
+        ).to(self.device)
+        expected_ea = torch.empty((0, self.edge_feature_dim)).to(
+            self.device
+        )  # Expect empty tensor
 
-        filtered_ei, mask = filter_edges(self.graph1.edge_index, node_index)
+        filtered_ei, filtered_ea, mask = filter_edges(
+            self.graph1.edge_index, node_index, self.graph1.edge_attr
+        )
 
-        self.assertTrue(torch.equal(filtered_ei, expected_edge_index))
-        self.assertEqual(filtered_ei.device.type, self.device.type)
-        self.assertEqual(mask.sum(), 0)
+        self.assertTrue(torch.equal(filtered_ei, expected_ei))
+        torch.testing.assert_close(filtered_ea, expected_ea)
+        self.assertTrue(torch.equal(mask, expected_mask))
+        self.assertEqual(filtered_ea.shape[0], 0)  # Check shape explicitly
 
-    def test_filter_edges_empty_selection(self):
-        """Test filtering with empty node_index."""
-        node_index = torch.tensor([], dtype=torch.long).to(self.device)
-        expected_edge_index = torch.empty((2, 0), dtype=torch.long).to(self.device)
-
-        filtered_ei, mask = filter_edges(self.graph1.edge_index, node_index)
-
-        self.assertTrue(torch.equal(filtered_ei, expected_edge_index))
-        self.assertEqual(filtered_ei.device.type, self.device.type)
-        self.assertEqual(mask.sum(), 0)
-
-    def test_build_masked_graph_basic(self):
-        """Test building a masked graph with features and positions."""
+    def test_build_masked_graph_with_attr(self):
+        """Test building a masked graph with edge attributes."""
         selected_indexes = torch.tensor([0, 1, 2], dtype=torch.long).to(self.device)
         graph_to_mask = self.graph1.clone()
 
-        masked_graph = build_masked_graph(graph_to_mask, selected_indexes)
+        masked_graph, edges_mask = build_masked_graph(graph_to_mask, selected_indexes)
 
-        expected_edge_index = torch.tensor(
-            [[0, 1, 1, 2], [1, 0, 2, 1]], dtype=torch.long
+        expected_ei = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]], dtype=torch.long).to(
+            self.device
+        )
+        expected_mask = torch.tensor(
+            [True, True, True, True, False, False], dtype=torch.bool
         ).to(self.device)
         expected_x = self.graph1.x[selected_indexes]
         expected_pos = self.graph1.pos[selected_indexes]
+        expected_ea = self.graph1.edge_attr[expected_mask]
 
         self.assertEqual(masked_graph.num_nodes, 3)
         torch.testing.assert_close(masked_graph.x, expected_x)
         torch.testing.assert_close(masked_graph.pos, expected_pos)
-        self.assertTrue(torch.equal(masked_graph.edge_index, expected_edge_index))
+        self.assertTrue(torch.equal(masked_graph.edge_index, expected_ei))
+        torch.testing.assert_close(masked_graph.edge_attr, expected_ea)
+        self.assertTrue(torch.equal(edges_mask, expected_mask))
+
+        # Check device consistency
         self.assertEqual(masked_graph.x.device.type, self.device.type)
         self.assertEqual(masked_graph.pos.device.type, self.device.type)
         self.assertEqual(masked_graph.edge_index.device.type, self.device.type)
+        self.assertEqual(masked_graph.edge_attr.device.type, self.device.type)
+        self.assertEqual(edges_mask.device.type, self.device.type)
 
-    def test_build_masked_graph_select_all(self):
-        """Test building a masked graph selecting all nodes (should be identity)."""
-        selected_indexes = torch.arange(self.graph1.num_nodes, dtype=torch.long).to(
-            self.device
-        )
-        graph_to_mask = self.graph1.clone()
+    def test_build_masked_graph_without_attr(self):
+        """Test building masked graph when original has no edge attributes."""
+        selected_indexes = torch.tensor([0, 1], dtype=torch.long).to(self.device)
+        graph_to_mask = self.graph2.clone()  # graph2 has no edge_attr or pos
+        masked_graph, edges_mask = build_masked_graph(graph_to_mask, selected_indexes)
+        expected_ei = torch.tensor([[0, 1], [1, 0]], dtype=torch.long).to(self.device)
+        expected_mask = torch.tensor([True, True], dtype=torch.bool).to(self.device)
+        expected_x = self.graph2.x[selected_indexes]
 
-        masked_graph = build_masked_graph(graph_to_mask, selected_indexes)
+        self.assertEqual(masked_graph.num_nodes, 2)
+        torch.testing.assert_close(masked_graph.x, expected_x)
+        self.assertTrue(torch.equal(masked_graph.edge_index, expected_ei))
+        self.assertFalse(getattr(masked_graph, "pos", None) is not None)
+        self.assertFalse(
+            getattr(masked_graph, "edge_attr", None) is not None
+        )  # Should not have edge_attr
+        self.assertTrue(torch.equal(edges_mask, expected_mask))
 
-        expected_edge_index = torch.tensor(
-            [[0, 1, 1, 2, 3, 4], [1, 0, 2, 1, 4, 3]], dtype=torch.long
-        ).to(self.device)
-
-        self.assertEqual(masked_graph.num_nodes, self.graph1.num_nodes)
-        torch.testing.assert_close(masked_graph.x, self.graph1.x)
-        torch.testing.assert_close(masked_graph.pos, self.graph1.pos)
-        self.assertTrue(torch.equal(masked_graph.edge_index, expected_edge_index))
-
-    def test_reconstruct_graph_basic(self):
-        """Test reconstructing a graph from its masked latent version."""
+    def test_reconstruct_graph_with_attr(self):
+        """Test reconstructing a graph including edge attributes."""
         original_graph = self.graph1.clone()
-        selected_indexes = torch.tensor([0, 2, 4], dtype=torch.long).to(self.device)
-        embedding_dim = original_graph.x.shape[1]
+        selected_nodes_idx = torch.tensor([0, 2, 4], dtype=torch.long).to(self.device)
+        num_selected_nodes = len(selected_nodes_idx)
 
-        # Simulate a latent masked graph (e.g., output of an encoder)
-        # Has features only for selected nodes (3 nodes), potentially modified
-        latent_x = torch.randn(3, embedding_dim).to(self.device)
-        latent_masked_graph = Data(x=latent_x).to(
+        # 1. Simulate building the masked graph to get the correct edges_mask and latent structure
+        # We only keep edges between selected nodes {0, 2, 4}. In graph1, there are NO edges between just these nodes.
+        # Let's change selection to {0, 1, 2} for a more interesting edge case.
+        selected_nodes_idx = torch.tensor([0, 1, 2], dtype=torch.long).to(self.device)
+        num_selected_nodes = len(selected_nodes_idx)
+        # Edges kept: (0,1), (1,0), (1,2), (2,1) -> Indices 0, 1, 2, 3 in original edge list
+        expected_edges_mask = torch.tensor(
+            [True, True, True, True, False, False], dtype=torch.bool
+        ).to(self.device)
+        num_kept_edges = expected_edges_mask.sum()
+
+        # 2. Create a *simulated* latent_masked_graph (output of some GNN)
+        # It should have node features for selected nodes and edge features for kept edges.
+        latent_node_x = torch.randn(num_selected_nodes, self.node_feature_dim).to(
             self.device
-        )  # Only need x for this function's perspective
-
-        # Mask token
-        mask_token = nn.Parameter(torch.zeros(embedding_dim, device=self.device))
-        mask_token.data += 0.5  # Give it a non-zero value for easier testing
-
-        reconstructed_graph = reconstruct_graph(
-            original_graph, latent_masked_graph, selected_indexes, mask_token
+        )
+        latent_edge_attr = torch.randn(num_kept_edges, self.edge_feature_dim).to(
+            self.device
+        )  # Use encoded dimension
+        # We don't strictly need the correct edge_index/pos in latent_masked_graph for reconstruct_graph, only x and edge_attr
+        latent_masked_graph = Data(x=latent_node_x, edge_attr=latent_edge_attr).to(
+            self.device
         )
 
+        # 3. Reconstruct
+        # Use identity encoder for simplicity here to match dimensions easily
+        reconstructed_graph = reconstruct_graph(
+            original_graph,
+            latent_masked_graph,
+            selected_nodes_idx,
+            self.node_mask_token,
+            expected_edges_mask,  # Pass the correct mask
+            edge_encoder=self.identity_encoder,  # Use identity
+            edge_mask_token=self.edge_mask_token,
+        )
+
+        # --- Assertions ---
+        # Node features
         self.assertEqual(reconstructed_graph.num_nodes, original_graph.num_nodes)
         self.assertEqual(reconstructed_graph.x.shape, original_graph.x.shape)
-        self.assertEqual(reconstructed_graph.x.device.type, self.device.type)
-
-        # Check selected nodes have features from latent graph
-        torch.testing.assert_close(reconstructed_graph.x[selected_indexes], latent_x)
-
-        # Check unselected nodes have the mask token
-        unselected_mask = torch.ones(
+        torch.testing.assert_close(
+            reconstructed_graph.x[selected_nodes_idx], latent_node_x
+        )
+        unselected_nodes_mask = torch.ones(
             original_graph.num_nodes, dtype=torch.bool, device=self.device
         )
-        unselected_mask[selected_indexes] = False
-        expected_mask_features = mask_token.data.unsqueeze(0).expand(
-            unselected_mask.sum(), -1
+        unselected_nodes_mask[selected_nodes_idx] = False
+        expected_node_mask_features = self.node_mask_token.expand(
+            unselected_nodes_mask.sum(), -1
         )
         torch.testing.assert_close(
-            reconstructed_graph.x[unselected_mask], expected_mask_features
+            reconstructed_graph.x[unselected_nodes_mask], expected_node_mask_features
         )
 
-        # Check other attributes are preserved
+        # Edge features
+        self.assertTrue(hasattr(reconstructed_graph, "edge_attr"))
+        self.assertEqual(
+            reconstructed_graph.edge_attr.shape, original_graph.edge_attr.shape
+        )
+
+        # - Check unmasked edges (where expected_edges_mask is True)
+        torch.testing.assert_close(
+            reconstructed_graph.edge_attr[expected_edges_mask], latent_edge_attr
+        )
+
+        # - Check masked edges (where expected_edges_mask is False)
+        masked_original_attrs = original_graph.edge_attr[~expected_edges_mask]
+        # Apply encoder (identity in this case) + mask token
+        expected_masked_edge_attrs = self.identity_encoder(
+            masked_original_attrs
+        ) + self.edge_mask_token.expand(masked_original_attrs.shape[0], -1)
+        torch.testing.assert_close(
+            reconstructed_graph.edge_attr[~expected_edges_mask],
+            expected_masked_edge_attrs,
+        )
+
+        # Other attributes (should be same as original)
         self.assertTrue(
             torch.equal(reconstructed_graph.edge_index, original_graph.edge_index)
         )
         torch.testing.assert_close(reconstructed_graph.pos, original_graph.pos)
-        self.assertEqual(reconstructed_graph.edge_index.device.type, self.device.type)
-        self.assertEqual(reconstructed_graph.pos.device.type, self.device.type)
 
-    def test_reconstruct_graph_select_all(self):
-        """Test reconstructing when all nodes were selected."""
-        original_graph = self.graph1.clone()
-        selected_indexes = torch.arange(original_graph.num_nodes, dtype=torch.long).to(
+    def test_reconstruct_graph_without_attr(self):
+        """Test reconstructing when the original graph had no edge attributes."""
+        original_graph = self.graph2.clone()  # graph2 has no edge_attr
+        selected_nodes_idx = torch.tensor([0], dtype=torch.long).to(
+            self.device
+        )  # Select just one node
+        num_selected_nodes = len(selected_nodes_idx)
+
+        # Edges mask: Graph2 edges are (0,1), (1,0). Selecting node 0 keeps no edges.
+        expected_edges_mask = torch.tensor([False, False], dtype=torch.bool).to(
             self.device
         )
-        embedding_dim = original_graph.x.shape[1]
+        num_kept_edges = 0
 
-        # Latent graph has features for all nodes
-        latent_x = torch.randn(original_graph.num_nodes, embedding_dim).to(self.device)
-        latent_masked_graph = Data(x=latent_x).to(self.device)
-
-        mask_token = nn.Parameter(torch.zeros(embedding_dim, device=self.device))
+        latent_node_x = torch.randn(num_selected_nodes, self.node_feature_dim).to(
+            self.device
+        )
+        # No latent edge attributes needed as original had none
+        latent_masked_graph = Data(x=latent_node_x).to(self.device)
 
         reconstructed_graph = reconstruct_graph(
-            original_graph, latent_masked_graph, selected_indexes, mask_token
+            original_graph,
+            latent_masked_graph,
+            selected_nodes_idx,
+            self.node_mask_token,
+            expected_edges_mask,  # Pass the mask
+            edge_encoder=None,  # No encoder needed
+            edge_mask_token=None,  # No token needed
         )
 
+        # Assertions
         self.assertEqual(reconstructed_graph.num_nodes, original_graph.num_nodes)
-        # All features should come from the latent graph
-        torch.testing.assert_close(reconstructed_graph.x, latent_x)
-        # Check other attributes
+        torch.testing.assert_close(
+            reconstructed_graph.x[selected_nodes_idx], latent_node_x
+        )
+        unselected_nodes_mask = torch.ones(
+            original_graph.num_nodes, dtype=torch.bool, device=self.device
+        )
+        unselected_nodes_mask[selected_nodes_idx] = False
+        expected_node_mask_features = self.node_mask_token.expand(
+            unselected_nodes_mask.sum(), -1
+        )
+        torch.testing.assert_close(
+            reconstructed_graph.x[unselected_nodes_mask], expected_node_mask_features
+        )
+
+        # Should NOT have edge attributes
+        self.assertFalse(getattr(reconstructed_graph, "edge_attr", None) is not None)
+
+        # Other attributes
         self.assertTrue(
             torch.equal(reconstructed_graph.edge_index, original_graph.edge_index)
         )
-        torch.testing.assert_close(reconstructed_graph.pos, original_graph.pos)
-
-    def test_reconstruct_graph_select_none(self):
-        """Test reconstructing when no nodes were selected."""
-        original_graph = self.graph1.clone()
-        selected_indexes = torch.tensor([], dtype=torch.long).to(self.device)
-        embedding_dim = original_graph.x.shape[1]
-
-        # Latent graph has features for 0 nodes
-        latent_x = torch.empty((0, embedding_dim), device=self.device)
-        latent_masked_graph = Data(x=latent_x).to(self.device)
-
-        mask_token = nn.Parameter(
-            torch.ones(embedding_dim, device=self.device) * -1.0
-        )  # Use a specific value
-
-        reconstructed_graph = reconstruct_graph(
-            original_graph, latent_masked_graph, selected_indexes, mask_token
-        )
-
-        self.assertEqual(reconstructed_graph.num_nodes, original_graph.num_nodes)
-        # All features should be the mask token
-        expected_mask_features = mask_token.data.unsqueeze(0).expand(
-            original_graph.num_nodes, -1
-        )
-        torch.testing.assert_close(reconstructed_graph.x, expected_mask_features)
-        # Check other attributes
-        self.assertTrue(
-            torch.equal(reconstructed_graph.edge_index, original_graph.edge_index)
-        )
-        torch.testing.assert_close(reconstructed_graph.pos, original_graph.pos)
+        self.assertFalse(
+            getattr(reconstructed_graph, "pos", None) is not None
+        )  # Graph 2 had no pos
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds function to mask a graph, and to reconstruct one following our work in Mesh Mask. 

- when masked: we simply remove a set of nodes and their connected edges
- when unmasking, our initial graph receives the latent values from the Encoder on Unmasked Nodes, and a [MASK] token on previously masked nodes. We don't do anything regarding the re-introduced edges. If they were removed before, we add them back. If you use `edge_features`, we use the same features as before, without any specific token.