### PR TITLE
22-dataloader-runtime-error-received-0-items-of-ancdata

### DIFF
--- a/graphphysics/predict.py
+++ b/graphphysics/predict.py
@@ -18,6 +18,7 @@ warnings.filterwarnings(
 )
 
 torch.set_float32_matmul_precision("high")
+torch.multiprocessing.set_sharing_strategy("file_system")
 
 FLAGS = flags.FLAGS
 flags.DEFINE_string("project_name", "prediction_project", "Name of the WandB project")

--- a/graphphysics/train.py
+++ b/graphphysics/train.py
@@ -26,6 +26,7 @@ warnings.filterwarnings(
 )
 
 torch.set_float32_matmul_precision("high")
+torch.multiprocessing.set_sharing_strategy("file_system")
 
 FLAGS = flags.FLAGS
 flags.DEFINE_string("project_name", "my_project", "Name of the WandB project")


### PR DESCRIPTION
To solve issue #22 : Changing the file descriptor sharing strategy to avoid FD leaks during testing/prediction phases with `num_workers` higher than 0 when training a transformer on cluster architecture . 

> [!NOTE]  
> Note that when using `num_workers`>0, this issue was encountered consistently with graphs of significant size (>15k nodes). 

Solution taken from [here](https://github.com/pytorch/pytorch/issues/973#issuecomment-449756587). 