### PR TITLE
16-prediction-outputs

### DIFF
--- a/graphphysics/dataset/xdmf_dataset.py
+++ b/graphphysics/dataset/xdmf_dataset.py
@@ -78,6 +78,7 @@ class XDMFDataset(BaseDataset):
         """
         traj_index, frame = self.get_traj_frame(index=index)
         xdmf_file = self.file_paths[traj_index]
+        mesh_id = os.path.splitext(os.path.basename(xdmf_file))[0].rsplit("_", 1)[-1]
 
         # Fetch index for previous_data and target
         _target_data_index = random.randint(1, self.random_next)
@@ -146,6 +147,7 @@ class XDMFDataset(BaseDataset):
             point_data=point_data,
             time=time,
             target=target_data,
+            id=mesh_id,
         )
         # TODO: add target_dt and previous_dt as features per node.
         graph.target_dt = _target_data_index * self.dt

--- a/graphphysics/predict.py
+++ b/graphphysics/predict.py
@@ -85,6 +85,7 @@ def main(argv):
         checkpoint_path=model_path,
         parameters=parameters,
         trajectory_length=predict_dataset.trajectory_length,
+        timestep=predict_dataset.dt,
     )
 
     # Initialize WandbLogger

--- a/graphphysics/train.py
+++ b/graphphysics/train.py
@@ -176,6 +176,7 @@ def main(argv):
             learning_rate=initial_lr,
             num_steps=num_steps,
             trajectory_length=train_dataset.trajectory_length,
+            timestep=train_dataset.dt,
             **prev_data_kwargs,
         )
         logger.info(f"Resuming WandB run: {lightning_module.wandb_run_id}")
@@ -187,6 +188,7 @@ def main(argv):
             num_steps=num_steps,
             warmup=warmup,
             trajectory_length=train_dataset.trajectory_length,
+            timestep=train_dataset.dt,
             **prev_data_kwargs,
         )
 

--- a/graphphysics/training/lightning_module.py
+++ b/graphphysics/training/lightning_module.py
@@ -125,6 +125,7 @@ class LightningModule(L.LightningModule):
         save_dir: str,
         archive_filename: str,
         timestep: float = 1,
+        add_id: bool = False,
     ):
         os.makedirs(save_dir, exist_ok=True)
         archive_path = os.path.join(save_dir, archive_filename)
@@ -132,25 +133,32 @@ class LightningModule(L.LightningModule):
             init_mesh = convert_to_meshio_vtu(trajectory[0], add_all_data=True)
             points = init_mesh.points
             cells = init_mesh.cells
-            with meshio.xdmf.TimeSeriesWriter(f"{archive_path}.xdmf") as writer:
+            xdmf_filename = (
+                f"{archive_path}_{trajectory[0].id[0]}.xdmf"
+                if (add_id and trajectory[0].id[0] is not None)
+                else f"{archive_path}.xdmf"
+            )
+            with meshio.xdmf.TimeSeriesWriter(xdmf_filename) as writer:
                 # Write the mesh (points and cells) once
                 writer.write_points_cells(points, cells)
                 # Loop through time steps and write data
-                t = 0
+                t = 0  # TODO: change to t=timestep or 2*timestep if previous_data
                 for idx, graph in enumerate(trajectory):
                     mesh = convert_to_meshio_vtu(graph, add_all_data=True)
                     point_data = mesh.point_data
                     cell_data = mesh.cell_data
                     writer.write_data(t, point_data=point_data, cell_data=cell_data)
-                    t += timestep
+                    t += timestep  # TODO: use the meta.dt timestep
 
         except Exception as e:
             logger.error(f"Error saving graph {idx} at epoch {self.current_epoch}: {e}")
         logger.info(f"Validation Trajectory saved at {save_dir}.")
         # The H5 archive is systematically created in cwd, we just need to move it
         shutil.move(
-            src=os.path.join(os.getcwd(), os.path.split(f"{archive_path}.h5")[1]),
-            dst=f"{archive_path}.h5",
+            src=os.path.join(
+                os.getcwd(), os.path.split(f"{xdmf_filename.replace('xdmf','h5')}")[1]
+            ),
+            dst=f"{xdmf_filename.replace('xdmf','h5')}",
         )
 
     def _reset_validation_trajectory(self):
@@ -252,7 +260,11 @@ class LightningModule(L.LightningModule):
         # Save trajectory graphs
         save_dir = os.path.join("meshes", f"epoch_{self.current_epoch}")
         self._save_trajectory_to_xdmf(
-            self.trajectory_to_save, save_dir, f"graph_epoch_{self.current_epoch}"
+            self.trajectory_to_save,
+            save_dir,
+            f"graph_epoch_{self.current_epoch}",
+            timestep=1,  # TODO: use the meta.dt timestep
+            add_id=True,
         )
 
         # Clear stored outputs
@@ -315,8 +327,14 @@ class LightningModule(L.LightningModule):
 
         save_dir = "predictions"
         os.makedirs(save_dir, exist_ok=True)
-        for traj_idx, trajectory in enumerate(self.prediction_trajectories):
-            self._save_trajectory_to_xdmf(trajectory, save_dir, f"graph_{traj_idx}")
+        for trajectory in self.prediction_trajectories:
+            self._save_trajectory_to_xdmf(
+                trajectory,
+                save_dir,
+                "graph",
+                timestep=1,  # TODO: use the meta.dt timestep
+                add_id=True,
+            )
 
         # Clear stored outputs
         self._reset_predict_epoch_end()

--- a/graphphysics/training/lightning_module.py
+++ b/graphphysics/training/lightning_module.py
@@ -33,6 +33,7 @@ class LightningModule(L.LightningModule):
         num_steps: int,
         warmup: int,
         trajectory_length: int = 599,
+        timestep: float = 1,
         only_processor: bool = False,
         masks: list[NodeType] = [NodeType.NORMAL, NodeType.OUTFLOW],
         use_previous_data: bool = False,
@@ -85,6 +86,7 @@ class LightningModule(L.LightningModule):
         self.val_step_outputs = []
         self.val_step_targets = []
         self.trajectory_length = trajectory_length
+        self.timestep = timestep
         self.current_val_trajectory = 0
         self.last_val_prediction = None
         self.last_previous_data_prediction = None
@@ -142,13 +144,13 @@ class LightningModule(L.LightningModule):
                 # Write the mesh (points and cells) once
                 writer.write_points_cells(points, cells)
                 # Loop through time steps and write data
-                t = 0  # TODO: change to t=timestep or 2*timestep if previous_data
+                t = 0  # TODO: take into account previous_data shift etc
                 for idx, graph in enumerate(trajectory):
                     mesh = convert_to_meshio_vtu(graph, add_all_data=True)
                     point_data = mesh.point_data
                     cell_data = mesh.cell_data
                     writer.write_data(t, point_data=point_data, cell_data=cell_data)
-                    t += timestep  # TODO: use the meta.dt timestep
+                    t += timestep
 
         except Exception as e:
             logger.error(f"Error saving graph {idx} at epoch {self.current_epoch}: {e}")
@@ -263,7 +265,7 @@ class LightningModule(L.LightningModule):
             self.trajectory_to_save,
             save_dir,
             f"graph_epoch_{self.current_epoch}",
-            timestep=1,  # TODO: use the meta.dt timestep
+            timestep=self.timestep,
             add_id=True,
         )
 
@@ -332,7 +334,7 @@ class LightningModule(L.LightningModule):
                 trajectory,
                 save_dir,
                 "graph",
-                timestep=1,  # TODO: use the meta.dt timestep
+                timestep=self.timestep,
                 add_id=True,
             )
 

--- a/graphphysics/utils/torch_graph.py
+++ b/graphphysics/utils/torch_graph.py
@@ -119,6 +119,7 @@ def meshdata_to_graph(
     time: Union[int, float] = 1,
     target: Optional[np.ndarray] = None,
     return_only_node_features: bool = False,
+    id: Optional[str] = None,
 ) -> Data:
     """Converts mesh data into a PyTorch Geometric Data object.
 
@@ -129,6 +130,7 @@ def meshdata_to_graph(
         time (int or float): A scalar value representing the time step.
         target (np.ndarray, optional): An optional target tensor.
         return_only_node_features (bool): Whether to return only node features.
+        id (str, optional): An optional mesh id to link graph to original dataset mesh.
 
     Returns:
         Data: A PyTorch Geometric Data object representing the mesh.
@@ -189,6 +191,7 @@ def meshdata_to_graph(
         tetra=tetra,
         y=target_features,
         pos=torch.tensor(points, dtype=torch.float32),
+        id=id,
     )
 
 


### PR DESCRIPTION
This brings some changes to how predictions are run: 

- Naming of saved prediction/validation trajectories: possibility to include a graph ID for xdmf datasets to better identify the predicted traj with its ground truth (for example if a traj from an xdmf dataset is cylinder_0033.xdmf, then its ID is 0033). Default behavior is to include ID in graph attributes (create `graph.id`). If no ID, then default behavior is to number traj by index (0,1,...), as before.
- Timesteps: predicted trajectories have a timestep that corresponds to actual frame timestep (using timestep value `"dt"` provided by user in `dataset_config/` meta json file)
- Saving on the fly: once a prediction for a traj is done, it is saved to xdmf directly instead of being stored until end of prediction epoch. This allows for prediction on multiple trajectories without memory issues.

Note that first frame (resp. first and second frames if `use_previous_data=true`) are not included in the saved trajectory, thus the traj length of a prediction is 1 (resp 2) smaller than dataset trajectory length.

Closes points discussed in issue #16 