### PR TITLE
Fix: remove MLP class and res connections

### DIFF
--- a/graphphysics/models/transolver.py
+++ b/graphphysics/models/transolver.py
@@ -129,7 +129,6 @@ class Transolver_plus_block(nn.Module):
             nb_of_layers=2,
             layer_norm=False,
             act=act,
-            res=False,
         )
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
@@ -178,7 +177,6 @@ class Model(nn.Module):
                 nb_of_layers=2,
                 layer_norm=False,
                 act=act,
-                res=False,
             )
         else:
             self.preprocess = build_mlp(
@@ -188,7 +186,6 @@ class Model(nn.Module):
                 nb_of_layers=2,
                 layer_norm=False,
                 act=act,
-                res=False,
             )
 
         self.n_hidden = n_hidden

--- a/graphphysics/train.py
+++ b/graphphysics/train.py
@@ -136,7 +136,6 @@ def main(argv):
         "batch_size": batch_size,
         "num_workers": num_workers,
         "exclude_keys": ["tetra"],
-        "pin_memory": device.type == "cuda",
     }
 
     valid_dataloader_kwargs = {
@@ -144,12 +143,11 @@ def main(argv):
         "shuffle": False,
         "batch_size": 1,
         "num_workers": num_workers,
-        "pin_memory": device.type == "cuda",
     }
 
     if train_dataset.type == "h5":
-        train_dataloader_kwargs["pin_memory"] = (device.type == "cuda")
-        valid_dataloader_kwargs["pin_memory"] = (device.type == "cuda")
+        train_dataloader_kwargs["pin_memory"] = device.type == "cuda"
+        valid_dataloader_kwargs["pin_memory"] = device.type == "cuda"
 
     # Update arguments if num_workers > 0
     if num_workers > 0:


### PR DESCRIPTION
In the [commit adding Transolver](https://github.com/DonsetPG/graph-physics/commit/e1628f7404bddb316169d8c460a8545b16811314) , we added a MLP class on top the build_mlp function to handle res connections. This change modifies the names of weights and biases, so that models trained with the previous version do not match these names. But res connections are actually not used in Transolver's MLPs. So we decide to return to the previous version of build_mlp fiunction, without a MLP class, so without res connections.